### PR TITLE
Fix build issue in Makefile

### DIFF
--- a/package/host/src/cli_app/Makefile
+++ b/package/host/src/cli_app/Makefile
@@ -27,7 +27,7 @@ lib$(TARGET).so: $(LIB_SRCS)
 	@$(CC) -shared -o $@ $(LIB_OBJS)
 	@$(RM) *.o
 
-$(TARGET): $(EXE_SRCS)
+$(TARGET): $(EXE_SRCS) lib$(TARGET).a
 	@echo "$@"
 	@$(CC) $^ -o $@ $(CFLAGS) $(LFLAGS)
 


### PR DESCRIPTION
This makefile will occasionally fail since the build target doesn't include the library in the list of dependencies, causing the linker to fail due to a non-deterministic build step.